### PR TITLE
Refactor: clean up Grafana export/import (folders, dashboards, datasources)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,30 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "atomic-waker"
@@ -25,15 +46,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -41,7 +62,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -52,15 +73,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
@@ -70,18 +91,30 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.21"
+version = "1.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link 0.2.0",
+]
 
 [[package]]
 name = "core-foundation"
@@ -100,6 +133,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "destructure_traitobject"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,12 +169,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "encoding_rs"
@@ -133,12 +187,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -146,6 +200,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "fnv"
@@ -170,9 +230,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -224,19 +284,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.5+wasi-0.2.4",
 ]
 
 [[package]]
@@ -249,17 +309,20 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 name = "grafana-exim"
 version = "0.1.0"
 dependencies = [
- "dotenv",
+ "log",
+ "log4rs",
  "reqwest",
+ "serde",
  "serde_json",
+ "serde_yaml",
  "tokio",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -276,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "http"
@@ -321,20 +384,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "hyper"
-version = "1.6.0"
+name = "humantime"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hyper"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -342,11 +413,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
@@ -375,41 +445,72 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -419,30 +520,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -450,72 +531,59 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -524,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -534,12 +602,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -549,6 +628,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,9 +645,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -566,27 +655,27 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -594,15 +683,53 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "log-mdc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
+
+[[package]]
+name = "log4rs"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e947bb896e702c711fccc2bf02ab2abb6072910693818d1d6b07ee2b9dfd86c"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "chrono",
+ "derive_more",
+ "fnv",
+ "humantime",
+ "libc",
+ "log",
+ "log-mdc",
+ "mock_instant",
+ "parking_lot",
+ "rand",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "thread-id",
+ "typemap-ors",
+ "unicode-segmentation",
+ "winapi",
+]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mime"
@@ -612,23 +739,29 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "mock_instant"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
 
 [[package]]
 name = "native-tls"
@@ -648,6 +781,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,9 +806,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -696,9 +838,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.108"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -707,10 +849,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
+name = "ordered-float"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -718,22 +869,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -754,10 +905,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.95"
+name = "potential_utf"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -773,30 +942,58 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -805,29 +1002,26 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
@@ -846,28 +1040,28 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -877,25 +1071,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
+name = "rustls-pki-types"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
- "rustls-pki-types",
+ "zeroize",
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
-
-[[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "b5a37813727b78798e53c2bec3f5e8fe12a6d6f8389bf9ca7802add4c9905ad8"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -904,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -916,11 +1104,11 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -944,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -954,18 +1142,38 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "341877e04a22458705eb4e131a1508483c877dca2792b3781d4e5d8a6019ec43"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.221"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c459bc0a14c840cb403fc14b148620de1e0778c96ecd6e0c8c3cacb6d8d00fe"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d6185cf75117e20e62b1ff867b9518577271e58abe0037c40bb4794969355ab0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -974,14 +1182,14 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "56177480b00303e689183f110b4e727bb4211d692c62d4fcd16d02be93077d40"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -997,6 +1205,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,36 +1225,33 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1050,9 +1268,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1102,22 +1320,52 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread-id"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99043e46c5a15af379c06add30d9c93a6c0e8849de00d244c4a2c417da128d80"
+dependencies = [
+ "libc",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1125,20 +1373,22 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1174,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1196,6 +1446,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -1224,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
@@ -1238,10 +1506,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.18"
+name = "typemap-ors"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "a68c24b707f02dd18f1e4ccceb9d49f2058c2fb86384ef9972592904d7a28867"
+dependencies = [
+ "unsafe-any-ors",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-any-ors"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a303d30665362d9680d7d91d78b23f5f899504d4f08b3c4cf08d055d87c0ad"
+dependencies = [
+ "destructure_traitobject",
+]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -1251,20 +1555,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -1289,36 +1588,46 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.5+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.0+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -1330,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1343,9 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1353,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1366,56 +1675,137 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "windows-link"
-version = "0.1.1"
+name = "winapi"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.0",
+ "windows-result 0.4.0",
+ "windows-strings 0.5.0",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-registry"
-version = "0.4.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-result",
- "windows-strings",
- "windows-targets 0.53.0",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1424,7 +1814,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1433,7 +1823,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1442,30 +1841,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1475,22 +1858,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1499,22 +1870,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1523,22 +1882,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1547,49 +1894,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
+name = "wit-bindgen"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -1599,14 +1925,34 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1637,10 +1983,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1649,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,10 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-dotenv = "0.15.0"
+log = "0.4.28"
+log4rs = "1.4.0"
 reqwest = { version = "0.12.15", features = ["json"] }
+serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+serde_yaml = "0.9.34"
 tokio = { version = "1.44.2", features = ["full"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,5 @@
 use std::env;
 use std::fs;
-use std::sync::OnceLock;
-
-static CONFIG: OnceLock<EnvConfig> = OnceLock::new();
-
-#[derive(Debug)]
-struct EnvConfig {
-    grafana_src_host: String,
-    grafana_src_api_key: String,
-    grafana_dst_host: String,
-    grafana_dst_api_key: String,
-}
 
 fn create_dir(dir_path: &str) {
     if let Ok(exist) = fs::exists(dir_path) {
@@ -26,306 +15,185 @@ fn list_dir(dir_path: &str) -> Vec<std::path::PathBuf> {
         .collect::<Result<Vec<_>, std::io::Error>>().unwrap()
 }
 
-async fn export_dashboards() {
-    let config = &CONFIG.get().unwrap();
+fn get_config(config_file: &str) -> Result<Grafana, Box<dyn std::error::Error>> {
+    let file = std::fs::File::open(config_file)
+        .map_err(|e| {
+            e
+        })?;
 
-    let current_dir = {
-        let current_dir = env::current_dir().unwrap();
-        current_dir.to_str().unwrap().to_string()
-    };
+    let config: Grafana = serde_yaml::from_reader(file)?;
 
-    let dashboards_dir = format!("{}/dashboards", current_dir);
-    let folders_dir = format!("{}/folders", current_dir);
+    Ok(config)
+}
 
-    create_dir(&dashboards_dir);
-    create_dir(&folders_dir);
+fn get_current_dir() -> Result<String, Box<dyn std::error::Error>> {
+    let current_dir = env::current_dir().map_err(|e|{
+        log::error!("failed to get current dir: {e}");
+        e
+    })?;
 
-    let grafana_src_api_key = format!("Bearer {}", config.grafana_src_api_key);
-    let auth_value = reqwest::header::HeaderValue::from_str(&grafana_src_api_key).unwrap();
-
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert(reqwest::header::AUTHORIZATION, auth_value);
-
-    let client = reqwest::Client::builder()
-        .default_headers(headers)
-        .timeout(std::time::Duration::from_secs(5))
-        .build()
-        .unwrap();
-
-    let endpoint = format!("{}/api/search?type=dash-db", config.grafana_src_host);
-
-    let dashboard_uids: Vec<String> = match client.get(&endpoint).send().await {
-        Err(_) => Vec::new(),
-        Ok(res) => {
-            res.json::<serde_json::Value>().await
-                .ok()
-                .and_then(|json| json.as_array().cloned())
-                .unwrap_or_default()
-                .into_iter()
-                .map(|d| d["uid"].as_str().unwrap().to_string())
-                .collect()        
+    let current_dir = match current_dir.to_str() {
+        Some(s) => s.to_string(),
+        None => {
+            let message = "failed to get current dir".to_string();
+            log::error!("{message}");
+            return Err(message.into())
         },
     };
 
-    let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
-
-    for uid in dashboard_uids {
-        let client = client.clone();
-        let dashboards_dir = dashboards_dir.clone();
-        let endpoint = format!("{}/api/dashboards/uid/{}", config.grafana_src_host, uid);
-
-        handles.push(tokio::spawn(async move {
-            match client.get(&endpoint).send().await {
-                Err(e) => eprintln!("Error fetching dashboard '{}' from '{}': {}", uid, endpoint, e),
-                Ok(res) => {
-                    if let Ok(mut json) = res.json::<serde_json::Value>().await {
-                        let dashboard_json = json.as_object_mut().unwrap();
-                        let folder_uid = dashboard_json["meta"]["folderUid"].as_str().unwrap().to_string();
-                        let dashboard = &mut dashboard_json["dashboard"].as_object_mut().unwrap();
-
-                        dashboard.remove("id");
-                        dashboard_json.remove("meta");
-
-                        dashboard_json.insert("folderUid".to_string(), serde_json::Value::String(folder_uid));
-                        dashboard_json.insert("overwrite".to_string(), serde_json::Value::Bool(true));
-
-                        let file = fs::File::create(format!("{}/{}.json", dashboards_dir, uid)).unwrap();
-                        serde_json::to_writer(file, &dashboard_json).unwrap();
-
-                        println!("Successfully saved dashboard: dashboards/{}.json", uid);
-                    }
-                }
-            }
-        }));
-    }
-
-    let endpoint = format!("{}/api/folders", config.grafana_src_host);
-
-    let folder_uids: Vec<String> = match client.get(&endpoint).send().await {
-        Err(_) => Vec::new(),
-        Ok(res) => {
-            res.json::<serde_json::Value>().await
-                .ok()
-                .and_then(|json| json.as_array().cloned())
-                .unwrap_or_default()
-                .into_iter()
-                .map(|d| d["uid"].as_str().unwrap().to_string())
-                .collect()        
-        },
-    };
-
-    for uid in folder_uids {
-        let client = client.clone();
-        let folders_dir = folders_dir.clone();
-        let endpoint = format!("{}/api/folders/{}", config.grafana_src_host, uid);
-
-        handles.push(tokio::spawn(async move {
-            match client.get(&endpoint).send().await {
-                Err(e) => eprintln!("Error fetching folder '{}' from '{}': {}", uid, endpoint, e),
-                Ok(res) => {
-                    if let Ok(mut json) = res.json::<serde_json::Value>().await {
-                        let folder_json = json.as_object_mut().unwrap();
-
-                        folder_json.remove("id");
-                        folder_json.insert("overwrite".to_string(), serde_json::Value::Bool(true));
-
-                        let file = fs::File::create(format!("{}/{}.json", folders_dir, uid)).unwrap();
-                        serde_json::to_writer(file, &folder_json).unwrap();
-                        println!("Successfully saved folder: folders/{}.json", uid);
-                    }
-                },
-            } 
-        }));
-    }
-
-    for handle in handles {
-        handle.await.unwrap();
-    }
-
-    export_datasources().await;
+    Ok(current_dir)
 }
 
-async fn import_dashboards() {
-    let config = &CONFIG.get().unwrap();
-
-    let current_dir = {
-        let current_dir = env::current_dir().unwrap();
-        current_dir.to_str().unwrap().to_string()
-    };
-
-    let folders_dir = format!("{}/folders", current_dir);
-    let dashboards_dir = format!("{}/dashboards", current_dir);
-
-    let grafana_dst_api_key = format!("Bearer {}", config.grafana_dst_api_key);
-    let auth_value = reqwest::header::HeaderValue::from_str(&grafana_dst_api_key).unwrap();
-
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert(reqwest::header::AUTHORIZATION, auth_value);
-
-    let client = reqwest::Client::builder()
-        .default_headers(headers)
-        .timeout(std::time::Duration::from_secs(5))
-        .build()
-        .unwrap();
-
-    let mut handles: Vec<tokio::task::JoinHandle<()>> =  Vec::new();
-
-    let folder_paths = list_dir(&folders_dir);
-
-    for path in folder_paths {
-        let file_content = fs::read_to_string(path).unwrap();
-        let json_data: serde_json::Value = serde_json::from_str(&file_content).unwrap();
-
-        let folder_uid = json_data.get("uid").unwrap().as_str().unwrap().to_string();
-        let mut endpoint = format!("{}/api/folders/{}", config.grafana_dst_host, folder_uid);
-        let client = client.clone();
-        let grafana_dst_host = config.grafana_dst_host.clone();
-
-        handles.push(tokio::spawn(async move {
-            let folder_exist: bool = client.get(&endpoint)
-                .send()
-                .await
-                .map(|res| res.status() == reqwest::StatusCode::OK)
-                .unwrap_or(false);
-
-            let method = if folder_exist {
-                reqwest::Method::PUT
-            } else {
-                endpoint = format!("{}/api/folders", grafana_dst_host);
-                reqwest::Method::POST
-            };
-
-            match client.request(method, &endpoint).json(&json_data).send().await {
-                Err(e) => eprintln!("Error importing folder '{}' to '{}': {}", folder_uid, endpoint, e),
-                Ok(res) => {
-                    if res.status() == reqwest::StatusCode::OK {
-                        println!("Successfully importing folder '{}' to '{}'", folder_uid, endpoint);
-                    } else {
-                        eprintln!("Failed to import folder '{}' to '{}' with status code {}", folder_uid, endpoint, res.status().as_u16());
-                    }
-                },
-            }
-        }));
-    }
-
-    for handle in handles.drain(..) {
-        handle.await.unwrap();
-    }
-
-    let dashboard_paths = list_dir(&dashboards_dir);
-
-    for path in dashboard_paths {
-        let file_content = fs::read_to_string(path).unwrap();
-        let json_data: serde_json::Value = serde_json::from_str(&file_content).unwrap();
-        let dashboard_uid = json_data["dashboard"].get("uid").unwrap().as_str().unwrap().to_string();
-
-        let endpoint = format!("{}/api/dashboards/db", config.grafana_dst_host);
-        let client = client.clone();
-
-        handles.push(tokio::spawn(async move {
-            match client.post(&endpoint).json(&json_data).send().await {
-                Err(e) => eprintln!("Error importing dashboard '{}' to '{}': {}", dashboard_uid, endpoint, e),
-                Ok(res) => {
-                    if res.status() == reqwest::StatusCode::OK {
-                        println!("Successfully importing dashboard '{}' to '{}'", dashboard_uid, endpoint);
-                    } else {
-                        eprintln!("Failed to import dashboard '{}' to '{}' with status code {}", dashboard_uid, endpoint, res.status().as_u16());
-                    }
-                },
-            }
-        }));
-    }
-
-    for handle in handles {
-        handle.await.unwrap();
-    }    
-
-    import_datasources().await;
+#[derive(Debug, serde::Deserialize)]
+struct Credential {
+    host: String,
+    api_key: String,
 }
 
-async fn export_datasources() {
-    let config = &CONFIG.get().unwrap();
+#[derive(Debug, serde::Deserialize)]
+struct Grafana {
+    src: Credential,
+    dst: Credential,
+}
 
-    let grafana_src_api_key = format!("Bearer {}", config.grafana_src_api_key);
-    let auth_value = reqwest::header::HeaderValue::from_str(&grafana_src_api_key).unwrap();
+impl Grafana {
+    async fn export_dashboards(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let current_dir = get_current_dir()?;
 
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert(reqwest::header::AUTHORIZATION, auth_value);
+        let dashboards_dir = format!("{current_dir}/dashboards");
+        let folders_dir = format!("{current_dir}/folders");
 
-    let client = reqwest::Client::builder()
-        .default_headers(headers)
-        .timeout(std::time::Duration::from_secs(5))
-        .build()
-        .unwrap();
+        create_dir(&dashboards_dir);
+        create_dir(&folders_dir);
 
-    let endpoint = format!("{}/api/datasources", config.grafana_src_host);
-    let datasources: Vec<serde_json::Value> = match client.get(&endpoint).send().await {
-        Err(_) => vec![],
-        Ok(res) => {
-            res.json::<serde_json::Value>().await
-                .ok()
-                .and_then(|json| json.as_array().cloned())
-                .unwrap_or_default()
-                .into_iter()
-                .map(|mut item| {
-                    if let Some(obj) = item.as_object_mut() {
-                        obj.remove("id");
-                        obj.remove("orgId");
-                    }
+        let auth_value = reqwest::header::HeaderValue::from_str(&self.src.api_key)
+            .map_err(|e| {
+                log::error!("failed to create AUTHORIZATION value: {e}");
+                e
+            })?;
 
-                    item
-                })
-                .collect()
-        }
-    };
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(reqwest::header::AUTHORIZATION, auth_value);
 
-    let current_dir = {
-        let current_dir = env::current_dir().unwrap();
-        current_dir.to_str().unwrap().to_string()
-    };
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .unwrap();
+        
+        let endpoint = format!("{}/api/search?type=dash-db", self.src.host);
 
-    let datasources_dir = format!("{}/datasources", current_dir);
-    create_dir(&datasources_dir);
-
-    for ds in datasources {
-        let uid = match ds["uid"].as_str() {
-            Some(uid) => uid,
-            None => continue,
+        let dashboard_uids: Vec<String> = match client.get(&endpoint).send().await {
+            Err(_) => Vec::new(),
+            Ok(res) => {
+                res.json::<serde_json::Value>().await
+                    .ok()
+                    .and_then(|json| json.as_array().cloned())
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|d| d["uid"].as_str().unwrap().to_string())
+                    .collect()        
+            },
         };
 
-        let file = fs::File::create(format!("{}/{}.json", datasources_dir, uid)).unwrap();
-        serde_json::to_writer(file, &ds).unwrap();
+        let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
 
-        println!("Successfully saved datasource: datasources/{}.json", uid);
+        for uid in dashboard_uids {
+            let client = client.clone();
+            let dashboards_dir = dashboards_dir.clone();
+            let endpoint = format!("{}/api/dashboards/uid/{}", self.src.host, uid);
+
+            handles.push(tokio::spawn(async move {
+                match client.get(&endpoint).send().await {
+                    Err(e) => log::error!("Error fetching dashboard '{}' from '{}': {}", uid, endpoint, e),
+                    Ok(response) => {
+                        if let Ok(mut json) = response.json::<serde_json::Value>().await {
+                            let dashboard_json = json.as_object_mut().unwrap();
+                            let folder_uid = dashboard_json["meta"]["folderUid"].as_str().unwrap().to_string();
+                            let dashboard = &mut dashboard_json["dashboard"].as_object_mut().unwrap();
+
+                            dashboard.remove("id");
+                            dashboard_json.remove("meta");
+
+                            dashboard_json.insert("folderUid".to_string(), serde_json::Value::String(folder_uid));
+                            dashboard_json.insert("overwrite".to_string(), serde_json::Value::Bool(true));
+
+                            let file = fs::File::create(format!("{}/{}.json", dashboards_dir, uid)).unwrap();
+                            serde_json::to_writer(file, &dashboard_json).unwrap();
+
+                            println!("Successfully saved dashboard: dashboards/{}.json", uid);
+                        }
+                    }
+                }
+            }));
+        }
+
+        let endpoint = format!("{}/api/folders", self.src.host);
+
+        let folder_uids: Vec<String> = match client.get(&endpoint).send().await {
+            Err(_) => Vec::new(),
+            Ok(res) => {
+                res.json::<serde_json::Value>().await
+                    .ok()
+                    .and_then(|json| json.as_array().cloned())
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|d| d["uid"].as_str().unwrap().to_string())
+                    .collect()        
+            },
+        };
+
+        for uid in folder_uids {
+            let client = client.clone();
+            let folders_dir = folders_dir.clone();
+            let endpoint = format!("{}/api/folders/{}", self.src.host, uid);
+
+            handles.push(tokio::spawn(async move {
+                match client.get(&endpoint).send().await {
+                    Err(e) => eprintln!("Error fetching folder '{}' from '{}': {}", uid, endpoint, e),
+                    Ok(res) => {
+                        if let Ok(mut json) = res.json::<serde_json::Value>().await {
+                            let folder_json = json.as_object_mut().unwrap();
+
+                            folder_json.remove("id");
+                            folder_json.insert("overwrite".to_string(), serde_json::Value::Bool(true));
+
+                            let file = fs::File::create(format!("{}/{}.json", folders_dir, uid)).unwrap();
+                            serde_json::to_writer(file, &folder_json).unwrap();
+                            println!("Successfully saved folder: folders/{}.json", uid);
+                        }
+                    },
+                } 
+            }));
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        self.export_datasources(current_dir).await?;
+        Ok(())
     }
-}
+    
+    async fn export_datasources(&self, current_dir: String) -> Result<(), Box<dyn std::error::Error>> {
+        let grafana_src_api_key = format!("Bearer {}", self.src.api_key);
+        let auth_value = reqwest::header::HeaderValue::from_str(&grafana_src_api_key)
+            .map_err(|e| {
+                log::error!("failed to create AUTHORIZATION value: {e}");
+                e
+            })?;
 
-async fn import_datasources() {
-    let config = &CONFIG.get().unwrap();
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(reqwest::header::AUTHORIZATION, auth_value);
 
-    let current_dir = {
-        let current_dir = env::current_dir().unwrap();
-        current_dir.to_str().unwrap().to_string()
-    };
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .unwrap();
 
-    let datasources_dir = format!("{}/datasources", current_dir);
-    let datasource_paths = list_dir(&datasources_dir);
-
-    let mut headers = reqwest::header::HeaderMap::new();
-    let api_key = format!("Bearer {}", config.grafana_dst_api_key);
-    headers.insert(reqwest::header::AUTHORIZATION, reqwest::header::HeaderValue::from_str(&api_key).unwrap());
-
-    let client = reqwest::Client::builder()
-        .default_headers(headers)
-        .timeout(std::time::Duration::from_secs(5))
-        .build()
-        .unwrap();
-
-    let endpoint = format!("{}/api/datasources", config.grafana_dst_host);
-
-    let dst_datasource_uids: Vec<serde_json::Value> = match client.get(&endpoint)
-        .send().
-        await {
+        let endpoint = format!("{}/api/datasources", self.src.host);
+        let datasources: Vec<serde_json::Value> = match client.get(&endpoint).send().await {
             Err(_) => vec![],
             Ok(res) => {
                 res.json::<serde_json::Value>().await
@@ -333,72 +201,220 @@ async fn import_datasources() {
                     .and_then(|json| json.as_array().cloned())
                     .unwrap_or_default()
                     .into_iter()
-                    .filter_map(|item| {
-                        item.as_object()
-                            .and_then(|obj| obj.get("uid").cloned())
+                    .map(|mut item| {
+                        if let Some(obj) = item.as_object_mut() {
+                            obj.remove("id");
+                            obj.remove("orgId");
+                        }
+
+                        item
                     })
-                    .collect()
+                .collect()
             }
-    };
-
-    let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
-
-    for path in datasource_paths {
-        let file_content = fs::read_to_string(path).unwrap();
-        let json_data: serde_json::Value = serde_json::from_str(&file_content).unwrap();
-
-        let datasource_uid = json_data.get("uid").unwrap().as_str().unwrap().to_string();
-
-        let (method, endpoint) = if dst_datasource_uids.contains(&serde_json::json!(datasource_uid)) {
-            (reqwest::Method::PUT, format!("{}/api/datasources/uid/{}", config.grafana_dst_host, datasource_uid))
-        } else {
-            (reqwest::Method::POST, format!("{}/api/datasources", config.grafana_dst_host))
         };
 
-        let client = client.clone();
+        let datasources_dir = format!("{}/datasources", current_dir);
+        create_dir(&datasources_dir);
 
-        handles.push(tokio::spawn(async move {
-            match client.request(method, &endpoint)
-                .json(&json_data)
-                .send()
-                .await {
-                    Err(e) => eprintln!("Error importing datasource '{}' to '{}': {:?}", datasource_uid, endpoint, e),
+        for ds in datasources {
+            let uid = match ds["uid"].as_str() {
+                Some(uid) => uid,
+                None => continue,
+            };
+
+            let file = fs::File::create(format!("{}/{}.json", datasources_dir, uid)).unwrap();
+            serde_json::to_writer(file, &ds).unwrap();
+
+            println!("Successfully saved datasource: datasources/{}.json", uid);
+        }
+
+        Ok(())
+    }
+
+    async fn import_dashboards(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let current_dir = get_current_dir()?;
+
+        let folders_dir = format!("{}/folders", current_dir);
+        let dashboards_dir = format!("{}/dashboards", current_dir);
+
+        let grafana_dst_api_key = format!("Bearer {}", self.dst.api_key);
+        let auth_value = reqwest::header::HeaderValue::from_str(&grafana_dst_api_key).unwrap();
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(reqwest::header::AUTHORIZATION, auth_value);
+
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .unwrap();
+
+        let mut handles: Vec<tokio::task::JoinHandle<()>> =  Vec::new();
+
+        let folder_paths = list_dir(&folders_dir);
+
+        for path in folder_paths {
+            let file_content = fs::read_to_string(path).unwrap();
+            let json_data: serde_json::Value = serde_json::from_str(&file_content).unwrap();
+
+            let folder_uid = json_data.get("uid").unwrap().as_str().unwrap().to_string();
+            let mut endpoint = format!("{}/api/folders/{}", self.dst.host, folder_uid);
+            let client = client.clone();
+            let grafana_dst_host = self.dst.host.clone();
+
+            handles.push(tokio::spawn(async move {
+                let folder_exist: bool = client.get(&endpoint)
+                    .send()
+                    .await
+                    .map(|res| res.status() == reqwest::StatusCode::OK)
+                    .unwrap_or(false);
+
+                let method = if folder_exist {
+                    reqwest::Method::PUT
+                } else {
+                    endpoint = format!("{}/api/folders", grafana_dst_host);
+                    reqwest::Method::POST
+                };
+
+                match client.request(method, &endpoint).json(&json_data).send().await {
+                    Err(e) => eprintln!("Error importing folder '{}' to '{}': {}", folder_uid, endpoint, e),
                     Ok(res) => {
                         if res.status() == reqwest::StatusCode::OK {
-                            println!("Successfully importing datasource '{}' to '{}'", datasource_uid, endpoint);
+                            println!("Successfully importing folder '{}' to '{}'", folder_uid, endpoint);
                         } else {
-                            eprintln!("Failed to import datasource '{}' to '{}' with status code {}", datasource_uid, endpoint, res.status().as_u16());
+                            eprintln!("Failed to import folder '{}' to '{}' with status code {}", folder_uid, endpoint, res.status().as_u16());
                         }
                     },
                 }
-        }));
-    }
+            }));
+        }
 
-    for handle in handles {
-        handle.await.unwrap();
+        for handle in handles.drain(..) {
+            handle.await.unwrap();
+        }
+
+        let dashboard_paths = list_dir(&dashboards_dir);
+
+        for path in dashboard_paths {
+            let file_content = fs::read_to_string(path).unwrap();
+            let json_data: serde_json::Value = serde_json::from_str(&file_content).unwrap();
+            let dashboard_uid = json_data["dashboard"].get("uid").unwrap().as_str().unwrap().to_string();
+
+            let endpoint = format!("{}/api/dashboards/db", self.dst.host);
+            let client = client.clone();
+
+            handles.push(tokio::spawn(async move {
+                match client.post(&endpoint).json(&json_data).send().await {
+                    Err(e) => eprintln!("Error importing dashboard '{}' to '{}': {}", dashboard_uid, endpoint, e),
+                    Ok(res) => {
+                        if res.status() == reqwest::StatusCode::OK {
+                            println!("Successfully importing dashboard '{}' to '{}'", dashboard_uid, endpoint);
+                        } else {
+                            eprintln!("Failed to import dashboard '{}' to '{}' with status code {}", dashboard_uid, endpoint, res.status().as_u16());
+                        }
+                    },
+                }
+            }));
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }    
+
+        self.import_datasources(&current_dir).await?;
+        Ok(())
+    }
+    
+    async fn import_datasources(&self, current_dir: &String) -> Result<(), Box<dyn std::error::Error>> {
+        let datasources_dir = format!("{}/datasources", current_dir);
+        let datasource_paths = list_dir(&datasources_dir);
+
+        let grafana_dst_api_key = format!("Bearer {}", self.dst.api_key);
+        let auth_value = reqwest::header::HeaderValue::from_str(&grafana_dst_api_key)
+            .map_err(|e| {
+                log::error!("failed to create AUTHORIZATION value: {e}");
+                e
+            })?;
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(reqwest::header::AUTHORIZATION, auth_value);
+
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .unwrap();
+
+        let endpoint = format!("{}/api/datasources", self.dst.host);
+
+        let dst_datasource_uids: Vec<serde_json::Value> = match client.get(&endpoint)
+            .send().
+            await {
+                Err(_) => vec![],
+                Ok(res) => {
+                    res.json::<serde_json::Value>().await
+                        .ok()
+                        .and_then(|json| json.as_array().cloned())
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter_map(|item| {
+                            item.as_object()
+                                .and_then(|obj| obj.get("uid").cloned())
+                        })
+                        .collect()
+                }
+            };
+
+        let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
+
+        for path in datasource_paths {
+            let file_content = fs::read_to_string(path).unwrap();
+            let json_data: serde_json::Value = serde_json::from_str(&file_content).unwrap();
+
+            let datasource_uid = json_data.get("uid").unwrap().as_str().unwrap().to_string();
+
+            let (method, endpoint) = if dst_datasource_uids.contains(&serde_json::json!(datasource_uid)) {
+                (reqwest::Method::PUT, format!("{}/api/datasources/uid/{}", self.dst.host, datasource_uid))
+            } else {
+                (reqwest::Method::POST, format!("{}/api/datasources", self.dst.host))
+            };
+
+            let client = client.clone();
+
+            handles.push(tokio::spawn(async move {
+                match client.request(method, &endpoint)
+                    .json(&json_data)
+                    .send()
+                    .await {
+                        Err(e) => eprintln!("Error importing datasource '{}' to '{}': {:?}", datasource_uid, endpoint, e),
+                        Ok(res) => {
+                            if res.status() == reqwest::StatusCode::OK {
+                                println!("Successfully importing datasource '{}' to '{}'", datasource_uid, endpoint);
+                            } else {
+                                eprintln!("Failed to import datasource '{}' to '{}' with status code {}", datasource_uid, endpoint, res.status().as_u16());
+                            }
+                        },
+                    }
+            }));
+
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        Ok(())
     }
 }
 
 #[tokio::main]
-async fn main() {
-    dotenv::dotenv().ok();
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config_file = std::env::var("CONFIG_FILE")
+        .expect("environment variable `CONFIG_FILE` not found");
 
-    CONFIG.set(EnvConfig {
-        grafana_src_host: std::env::var("GRAFANA_SRC_HOST").expect("GRAFANA_SRC_HOST must be set"),
-        grafana_src_api_key: std::env::var("GRAFANA_SRC_API_KEY").expect("GRAFANA_SRC_API_KEY must be set"),
-        grafana_dst_host: std::env::var("GRAFANA_DST_HOST").expect("GRAFANA_DST_HOST must be set"),
-        grafana_dst_api_key: std::env::var("GRAFANA_DST_API_KEY").expect("GRAFANA_DST_API_KEY must be set"),
-    }).unwrap();
+    let grafana = get_config(&config_file)?;
+    grafana.export_dashboards().await?;
+    grafana.import_dashboards().await?;
 
-    let args: Vec<String> = env::args().collect();
-
-    if args.len() != 2 {
-        eprintln!("Usage: {} <export | import>", args[0]);
-    } else {
-        match args[1].as_str() {
-            "export" => export_dashboards().await,
-            "import" => import_dashboards().await,
-            other => eprintln!("{}: '{}' it's not a valid argument\n\nHere's the available argument:\n- export\n- import", args[0], other),
-        }
-    }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,410 +1,377 @@
 use std::env;
 use std::fs;
-
-fn create_dir(dir_path: &str) {
-    if let Ok(exist) = fs::exists(dir_path) {
-        if !exist {
-            fs::create_dir(dir_path).unwrap();
-        }
-    }
-}
-
-fn list_dir(dir_path: &str) -> Vec<std::path::PathBuf> {
-    fs::read_dir(dir_path).unwrap()
-        .map(|res| res.map(|e| e.path()))
-        .collect::<Result<Vec<_>, std::io::Error>>().unwrap()
-}
-
-fn get_config(config_file: &str) -> Result<Grafana, Box<dyn std::error::Error>> {
-    let file = std::fs::File::open(config_file)
-        .map_err(|e| {
-            e
-        })?;
-
-    let config: Grafana = serde_yaml::from_reader(file)?;
-
-    Ok(config)
-}
-
-fn get_current_dir() -> Result<String, Box<dyn std::error::Error>> {
-    let current_dir = env::current_dir().map_err(|e|{
-        log::error!("failed to get current dir: {e}");
-        e
-    })?;
-
-    let current_dir = match current_dir.to_str() {
-        Some(s) => s.to_string(),
-        None => {
-            let message = "failed to get current dir".to_string();
-            log::error!("{message}");
-            return Err(message.into())
-        },
-    };
-
-    Ok(current_dir)
-}
+use std::error::Error;
 
 #[derive(Debug, serde::Deserialize)]
-struct Credential {
+struct ServiceConfig {
     host: String,
     api_key: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
 struct Grafana {
-    src: Credential,
-    dst: Credential,
+    src: ServiceConfig,
+    dst: ServiceConfig,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct LogConfig {
+    pub filepath: String
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct Config {
+    grafana: Grafana,
+    log_config: LogConfig,
 }
 
 impl Grafana {
-    async fn export_dashboards(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let current_dir = get_current_dir()?;
-
-        let dashboards_dir = format!("{current_dir}/dashboards");
-        let folders_dir = format!("{current_dir}/folders");
-
-        create_dir(&dashboards_dir);
-        create_dir(&folders_dir);
-
-        let auth_value = reqwest::header::HeaderValue::from_str(&self.src.api_key)
-            .map_err(|e| {
-                log::error!("failed to create AUTHORIZATION value: {e}");
-                e
-            })?;
-
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(reqwest::header::AUTHORIZATION, auth_value);
-
-        let client = reqwest::Client::builder()
-            .default_headers(headers)
-            .timeout(std::time::Duration::from_secs(5))
-            .build()
-            .unwrap();
-        
-        let endpoint = format!("{}/api/search?type=dash-db", self.src.host);
-
-        let dashboard_uids: Vec<String> = match client.get(&endpoint).send().await {
-            Err(_) => Vec::new(),
-            Ok(res) => {
-                res.json::<serde_json::Value>().await
-                    .ok()
-                    .and_then(|json| json.as_array().cloned())
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|d| d["uid"].as_str().unwrap().to_string())
-                    .collect()        
-            },
-        };
-
-        let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
-
-        for uid in dashboard_uids {
-            let client = client.clone();
-            let dashboards_dir = dashboards_dir.clone();
-            let endpoint = format!("{}/api/dashboards/uid/{}", self.src.host, uid);
-
-            handles.push(tokio::spawn(async move {
-                match client.get(&endpoint).send().await {
-                    Err(e) => log::error!("Error fetching dashboard '{}' from '{}': {}", uid, endpoint, e),
-                    Ok(response) => {
-                        if let Ok(mut json) = response.json::<serde_json::Value>().await {
-                            let dashboard_json = json.as_object_mut().unwrap();
-                            let folder_uid = dashboard_json["meta"]["folderUid"].as_str().unwrap().to_string();
-                            let dashboard = &mut dashboard_json["dashboard"].as_object_mut().unwrap();
-
-                            dashboard.remove("id");
-                            dashboard_json.remove("meta");
-
-                            dashboard_json.insert("folderUid".to_string(), serde_json::Value::String(folder_uid));
-                            dashboard_json.insert("overwrite".to_string(), serde_json::Value::Bool(true));
-
-                            let file = fs::File::create(format!("{}/{}.json", dashboards_dir, uid)).unwrap();
-                            serde_json::to_writer(file, &dashboard_json).unwrap();
-
-                            println!("Successfully saved dashboard: dashboards/{}.json", uid);
-                        }
-                    }
-                }
-            }));
-        }
-
-        let endpoint = format!("{}/api/folders", self.src.host);
-
-        let folder_uids: Vec<String> = match client.get(&endpoint).send().await {
-            Err(_) => Vec::new(),
-            Ok(res) => {
-                res.json::<serde_json::Value>().await
-                    .ok()
-                    .and_then(|json| json.as_array().cloned())
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|d| d["uid"].as_str().unwrap().to_string())
-                    .collect()        
-            },
-        };
-
-        for uid in folder_uids {
-            let client = client.clone();
-            let folders_dir = folders_dir.clone();
-            let endpoint = format!("{}/api/folders/{}", self.src.host, uid);
-
-            handles.push(tokio::spawn(async move {
-                match client.get(&endpoint).send().await {
-                    Err(e) => eprintln!("Error fetching folder '{}' from '{}': {}", uid, endpoint, e),
-                    Ok(res) => {
-                        if let Ok(mut json) = res.json::<serde_json::Value>().await {
-                            let folder_json = json.as_object_mut().unwrap();
-
-                            folder_json.remove("id");
-                            folder_json.insert("overwrite".to_string(), serde_json::Value::Bool(true));
-
-                            let file = fs::File::create(format!("{}/{}.json", folders_dir, uid)).unwrap();
-                            serde_json::to_writer(file, &folder_json).unwrap();
-                            println!("Successfully saved folder: folders/{}.json", uid);
-                        }
-                    },
-                } 
-            }));
-        }
-
-        for handle in handles {
-            handle.await.unwrap();
-        }
-
-        self.export_datasources(current_dir).await?;
-        Ok(())
-    }
-    
-    async fn export_datasources(&self, current_dir: String) -> Result<(), Box<dyn std::error::Error>> {
-        let grafana_src_api_key = format!("Bearer {}", self.src.api_key);
-        let auth_value = reqwest::header::HeaderValue::from_str(&grafana_src_api_key)
-            .map_err(|e| {
-                log::error!("failed to create AUTHORIZATION value: {e}");
-                e
-            })?;
-
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(reqwest::header::AUTHORIZATION, auth_value);
-
-        let client = reqwest::Client::builder()
-            .default_headers(headers)
-            .timeout(std::time::Duration::from_secs(5))
-            .build()
-            .unwrap();
-
-        let endpoint = format!("{}/api/datasources", self.src.host);
-        let datasources: Vec<serde_json::Value> = match client.get(&endpoint).send().await {
-            Err(_) => vec![],
-            Ok(res) => {
-                res.json::<serde_json::Value>().await
-                    .ok()
-                    .and_then(|json| json.as_array().cloned())
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|mut item| {
-                        if let Some(obj) = item.as_object_mut() {
-                            obj.remove("id");
-                            obj.remove("orgId");
-                        }
-
-                        item
-                    })
-                .collect()
-            }
-        };
-
-        let datasources_dir = format!("{}/datasources", current_dir);
-        create_dir(&datasources_dir);
-
-        for ds in datasources {
-            let uid = match ds["uid"].as_str() {
-                Some(uid) => uid,
-                None => continue,
-            };
-
-            let file = fs::File::create(format!("{}/{}.json", datasources_dir, uid)).unwrap();
-            serde_json::to_writer(file, &ds).unwrap();
-
-            println!("Successfully saved datasource: datasources/{}.json", uid);
-        }
-
-        Ok(())
-    }
-
-    async fn import_dashboards(&self) -> Result<(), Box<dyn std::error::Error>> {
+    async fn export(&self) -> Result<(), Box<dyn Error>> {
         let current_dir = get_current_dir()?;
 
         let folders_dir = format!("{}/folders", current_dir);
         let dashboards_dir = format!("{}/dashboards", current_dir);
+        let datasource_dir = format!("{}/datasources", current_dir);
 
-        let grafana_dst_api_key = format!("Bearer {}", self.dst.api_key);
-        let auth_value = reqwest::header::HeaderValue::from_str(&grafana_dst_api_key).unwrap();
+        create_dir(&folders_dir)?;
+        create_dir(&dashboards_dir)?;
+        create_dir(&datasource_dir)?;
+
+        let client = self.create_request_client(&self.src.api_key)?;
+
+        self.export_folders_to_file(&client, &folders_dir).await?;
+        self.export_dashboards_to_file(&client, &dashboards_dir).await?;
+        self.export_datasources_to_file(&client, &datasource_dir).await?;
+
+        Ok(())
+    }
+
+    async fn import(&self) -> Result<(), Box<dyn Error>> {
+        let client = self.create_request_client(&self.dst.api_key)?;
+
+        self.import_folders_from_files(&client).await?;
+        self.import_dashboards_from_files(&client).await?;
+        self.import_datasources_from_files(&client).await?;
+
+        Ok(())
+    }
+
+    fn create_request_client(&self, api_key: &str) -> Result<reqwest::Client, Box<dyn Error>> {
+        let auth_value = reqwest::header::HeaderValue::from_str(&format!("Bearer {}", api_key)).map_err(|e| {
+            log::error!("Failed to create AUTHORIZATION value: {}", e);
+            e
+        })?;
 
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert(reqwest::header::AUTHORIZATION, auth_value);
 
+        let retry_policy = reqwest::retry::never().max_retries_per_request(5);
+
         let client = reqwest::Client::builder()
+            .retry(retry_policy)
             .default_headers(headers)
             .timeout(std::time::Duration::from_secs(5))
             .build()
-            .unwrap();
+            .map_err(|e| {
+                log::error!("Failed to create HTTP client: {}", e);
+                e
+            })?;
 
-        let mut handles: Vec<tokio::task::JoinHandle<()>> =  Vec::new();
+        Ok(client)
+    }
 
-        let folder_paths = list_dir(&folders_dir);
+    async fn export_folders_to_file(
+        &self,
+        client: &reqwest::Client,
+        folders_dir: &str
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let endpoint = format!("{}/api/folders", self.src.host);
+        let response = client.get(&endpoint).send().await?;
 
-        for path in folder_paths {
-            let file_content = fs::read_to_string(path).unwrap();
-            let json_data: serde_json::Value = serde_json::from_str(&file_content).unwrap();
+        let folder_uids: Vec<String> = response.json::<serde_json::Value>().await?
+            .as_array()
+            .map(|array| {
+                array.iter().filter_map(|d| d["uid"].as_str()).map(|s| s.to_string()).collect()
+            })
+            .unwrap_or_default();
 
-            let folder_uid = json_data.get("uid").unwrap().as_str().unwrap().to_string();
-            let mut endpoint = format!("{}/api/folders/{}", self.dst.host, folder_uid);
-            let client = client.clone();
-            let grafana_dst_host = self.dst.host.clone();
 
-            handles.push(tokio::spawn(async move {
-                let folder_exist: bool = client.get(&endpoint)
+        for uid in folder_uids {
+            let folders_dir = folders_dir.to_string();
+            let endpoint = format!("{}/api/folders/{}", self.src.host, uid);
+
+            match client.get(&endpoint).send().await {
+                Err(e) => log::error!("Error fetching folder '{}' from '{}': {}", uid, endpoint, e),
+                Ok(response) => {
+                    if let Ok(mut json) = response.json::<serde_json::Value>().await {
+                        let folder_json = json.as_object_mut().unwrap();
+
+                        folder_json.remove("id");
+                        folder_json.insert("overwrite".to_string(), serde_json::Value::Bool(true));
+
+                        let file_path = format!("{}/{}.json", folders_dir, uid);
+
+                        match fs::File::create(&file_path) {
+                            Err(e) => log::error!("Error saving folder '{}': {}", uid, e),
+                            Ok(f) => {
+                                if let Err(e) = serde_json::to_writer(f, &folder_json) {
+                                    log::error!("Error saving folder '{}': {}", uid, e);
+                                } else {
+                                    log::info!("Successfully saved folder: {}", file_path);
+                                }
+                            },
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn fetch_dashboard_uids(&self, client: &reqwest::Client) -> Result<Vec<String>, Box<dyn Error>> {
+        let endpoint = format!("{}/api/search?type=dash-db", self.src.host);
+        let response = client.get(&endpoint).send().await?;
+
+        let dashboard_uids: Vec<String> = response.json::<serde_json::Value>().await?
+            .as_array()
+            .map(|array| array.iter().filter_map(|d| d["uid"].as_str()).map(|s| s.to_string()).collect())
+            .unwrap_or_default();
+
+        Ok(dashboard_uids)
+    }
+
+    async fn export_dashboards_to_file(
+        &self,
+        client: &reqwest::Client,
+        dashboards_dir: &str
+    ) -> Result<(), Box<dyn Error>> {
+        let dashboard_uids = self.fetch_dashboard_uids(&client).await?;
+
+        for uid in dashboard_uids {
+            let dashboards_dir = dashboards_dir.to_string();
+            let endpoint = format!("{}/api/dashboards/uid/{}", self.src.host, uid);
+
+            match client.get(&endpoint).send().await {
+                Err(e) => log::error!("Error fetching dashboard '{}' from '{}': {}", uid, endpoint, e),
+                Ok(response) => {
+                    if let Ok(mut json) = response.json::<serde_json::Value>().await {
+                        let dashboard_json = json.as_object_mut().unwrap();
+                        let folder_uid = dashboard_json["meta"]["folderUid"].as_str().unwrap().to_string();
+                        let dashboard = &mut dashboard_json["dashboard"].as_object_mut().unwrap();
+
+                        dashboard.remove("id");
+                        dashboard_json.remove("meta");
+
+                        dashboard_json.insert("folderUid".to_string(), serde_json::Value::String(folder_uid));
+                        dashboard_json.insert("overwrite".to_string(), serde_json::Value::Bool(true));
+
+                        let file_path = format!("{}/{}.json", dashboards_dir, uid);
+
+                        match fs::File::create(&file_path) {
+                            Err(e) => log::error!("Error saving dashboard '{}': {}", uid, e),
+                            Ok(f) => {
+                                if let Err(e) = serde_json::to_writer(f, &dashboard_json) {
+                                    log::error!("Error saving dashboard '{}': {}", uid, e);
+                                } else {
+                                    log::info!("Successfully saved dashboard: {}", file_path);
+                                }
+                            },
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn export_datasources_to_file(
+        &self,
+        client: &reqwest::Client,
+        datasources_dir: &str
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let endpoint = format!("{}/api/datasources", self.src.host);
+        let response = client.get(&endpoint).send().await?;
+        let datasources: Vec<serde_json::Value> = response.json::<serde_json::Value>().await?
+            .as_array()
+            .map(|array| {
+                array.iter().filter_map(|item| {
+                    let mut item_clone = item.clone();
+                    item_clone.as_object_mut().map(|obj| {
+                        obj.remove("id");
+                        obj.remove("orgId");
+                    });
+                    Some(item_clone)
+                }).collect()
+            }).unwrap_or_default();
+
+        for ds in datasources {
+            if let Some(uid) = ds["uid"].as_str() {
+                let file_path = format!("{}/{}.json", datasources_dir, uid);
+
+                match fs::File::create(&file_path) {
+                    Err(e) => log::error!("Failed to save datasource '{}': {}", uid, e),
+                    Ok(f) => {
+                        if let Err(e) = serde_json::to_writer(f, &ds) {
+                            log::error!("Failed to save datasource '{}': {}", uid, e);
+                        } else {
+                            log::info!("Successfully saved datasource: {}", file_path);
+                        }
+                    },
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn import_folders_from_files(&self, client: &reqwest::Client) -> Result<(), Box<dyn Error>> {
+        let current_dir = get_current_dir()?;
+        let folders_dir = format!("{}/folders", current_dir);
+
+        for path in list_dir(&folders_dir) {
+            let file_content = fs::read_to_string(&path).map_err(|e| {
+                log::error!("Failed to read folder file '{}': {}", path.display(), e);
+                e
+            })?;
+
+            let json_data: serde_json::Value = serde_json::from_str(&file_content)?;
+
+            if let Some(folder_uid) = json_data.get("uid").and_then(|value| value.as_str()) {
+                let mut endpoint = format!("{}/api/folders/{}", self.dst.host, folder_uid);
+                let folder_exists = client.get(&endpoint)
                     .send()
                     .await
-                    .map(|res| res.status() == reqwest::StatusCode::OK)
-                    .unwrap_or(false);
+                    .map_or(false, |res| res.status() == reqwest::StatusCode::OK);
 
-                let method = if folder_exist {
+                let method = if folder_exists {
                     reqwest::Method::PUT
                 } else {
-                    endpoint = format!("{}/api/folders", grafana_dst_host);
+                    endpoint = format!("{}/api/folders", self.dst.host);
                     reqwest::Method::POST
                 };
 
                 match client.request(method, &endpoint).json(&json_data).send().await {
-                    Err(e) => eprintln!("Error importing folder '{}' to '{}': {}", folder_uid, endpoint, e),
+                    Err(e) => log::error!("Error importing folder '{}' to '{}': {}", folder_uid, endpoint, e),
                     Ok(res) => {
-                        if res.status() == reqwest::StatusCode::OK {
-                            println!("Successfully importing folder '{}' to '{}'", folder_uid, endpoint);
-                        } else {
-                            eprintln!("Failed to import folder '{}' to '{}' with status code {}", folder_uid, endpoint, res.status().as_u16());
-                        }
-                    },
+                        log::info!("Importing folder '{}' to '{}' with status {}", folder_uid, endpoint, res.status());
+                    }
                 }
-            }));
+            }
         }
 
-        for handle in handles.drain(..) {
-            handle.await.unwrap();
-        }
-
-        let dashboard_paths = list_dir(&dashboards_dir);
-
-        for path in dashboard_paths {
-            let file_content = fs::read_to_string(path).unwrap();
-            let json_data: serde_json::Value = serde_json::from_str(&file_content).unwrap();
-            let dashboard_uid = json_data["dashboard"].get("uid").unwrap().as_str().unwrap().to_string();
-
-            let endpoint = format!("{}/api/dashboards/db", self.dst.host);
-            let client = client.clone();
-
-            handles.push(tokio::spawn(async move {
-                match client.post(&endpoint).json(&json_data).send().await {
-                    Err(e) => eprintln!("Error importing dashboard '{}' to '{}': {}", dashboard_uid, endpoint, e),
-                    Ok(res) => {
-                        if res.status() == reqwest::StatusCode::OK {
-                            println!("Successfully importing dashboard '{}' to '{}'", dashboard_uid, endpoint);
-                        } else {
-                            eprintln!("Failed to import dashboard '{}' to '{}' with status code {}", dashboard_uid, endpoint, res.status().as_u16());
-                        }
-                    },
-                }
-            }));
-        }
-
-        for handle in handles {
-            handle.await.unwrap();
-        }    
-
-        self.import_datasources(&current_dir).await?;
         Ok(())
     }
-    
-    async fn import_datasources(&self, current_dir: &String) -> Result<(), Box<dyn std::error::Error>> {
-        let datasources_dir = format!("{}/datasources", current_dir);
-        let datasource_paths = list_dir(&datasources_dir);
 
-        let grafana_dst_api_key = format!("Bearer {}", self.dst.api_key);
-        let auth_value = reqwest::header::HeaderValue::from_str(&grafana_dst_api_key)
-            .map_err(|e| {
-                log::error!("failed to create AUTHORIZATION value: {e}");
+    async fn import_dashboards_from_files(&self, client: &reqwest::Client) -> Result<(), Box<dyn Error>> {
+        let current_dir = get_current_dir()?;
+        let dashboards_dir = format!("{}/dashboards", current_dir);
+
+        for path in list_dir(&dashboards_dir) {
+            let file_content = fs::read_to_string(&path).map_err(|e| {
+                log::error!("Failed to read dashboard file '{}': {}", path.display(), e);
                 e
             })?;
 
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(reqwest::header::AUTHORIZATION, auth_value);
-
-        let client = reqwest::Client::builder()
-            .default_headers(headers)
-            .timeout(std::time::Duration::from_secs(5))
-            .build()
-            .unwrap();
-
-        let endpoint = format!("{}/api/datasources", self.dst.host);
-
-        let dst_datasource_uids: Vec<serde_json::Value> = match client.get(&endpoint)
-            .send().
-            await {
-                Err(_) => vec![],
-                Ok(res) => {
-                    res.json::<serde_json::Value>().await
-                        .ok()
-                        .and_then(|json| json.as_array().cloned())
-                        .unwrap_or_default()
-                        .into_iter()
-                        .filter_map(|item| {
-                            item.as_object()
-                                .and_then(|obj| obj.get("uid").cloned())
-                        })
-                        .collect()
+            let json_data: serde_json::Value = serde_json::from_str(&file_content)?;
+            if let Some(dashboard_uid) = json_data["dashboard"].get("uid").and_then(|value| value.as_str()) {
+                let endpoint = format!("{}/api/dashboards/db", self.dst.host);
+                match client.post(&endpoint).json(&json_data).send().await {
+                    Err(e) => log::error!("Error importing dashboard '{}' to '{}': {}", dashboard_uid, endpoint, e),
+                    Ok(res) => log::info!("Importing dashboard '{}' to '{}' with status {}", dashboard_uid, endpoint, res.status()),
                 }
-            };
-
-        let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
-
-        for path in datasource_paths {
-            let file_content = fs::read_to_string(path).unwrap();
-            let json_data: serde_json::Value = serde_json::from_str(&file_content).unwrap();
-
-            let datasource_uid = json_data.get("uid").unwrap().as_str().unwrap().to_string();
-
-            let (method, endpoint) = if dst_datasource_uids.contains(&serde_json::json!(datasource_uid)) {
-                (reqwest::Method::PUT, format!("{}/api/datasources/uid/{}", self.dst.host, datasource_uid))
-            } else {
-                (reqwest::Method::POST, format!("{}/api/datasources", self.dst.host))
-            };
-
-            let client = client.clone();
-
-            handles.push(tokio::spawn(async move {
-                match client.request(method, &endpoint)
-                    .json(&json_data)
-                    .send()
-                    .await {
-                        Err(e) => eprintln!("Error importing datasource '{}' to '{}': {:?}", datasource_uid, endpoint, e),
-                        Ok(res) => {
-                            if res.status() == reqwest::StatusCode::OK {
-                                println!("Successfully importing datasource '{}' to '{}'", datasource_uid, endpoint);
-                            } else {
-                                eprintln!("Failed to import datasource '{}' to '{}' with status code {}", datasource_uid, endpoint, res.status().as_u16());
-                            }
-                        },
-                    }
-            }));
-
-        }
-
-        for handle in handles {
-            handle.await.unwrap();
+            }
         }
 
         Ok(())
     }
+
+    async fn import_datasources_from_files(&self, client: &reqwest::Client) -> Result<(), Box<dyn Error>> {
+        let current_dir = get_current_dir()?;
+        let datasources_dir = format!("{}/datasources", current_dir);
+        let datasource_paths = list_dir(&datasources_dir);
+
+        let endpoint = format!("{}/api/datasources", self.dst.host);
+        let response = client.get(&endpoint).send().await?;
+        let dst_datasource_uids: Vec<String> = response.json::<serde_json::Value>().await?
+            .as_array()
+            .map(|array| array.iter().filter_map(|item|
+                item.get("uid").and_then(|uid| uid.as_str()).map(|s| s.to_string())
+            ).collect())
+            .unwrap_or_default();
+
+        for path in datasource_paths {
+            let file_content = fs::read_to_string(&path).map_err(|e| {
+                log::error!("Failed to read datasource file '{}': {}", path.display(), e);
+                e
+            })?;
+
+            let json_data: serde_json::Value = serde_json::from_str(&file_content)?;
+            if let Some(datasource_uid) = json_data.get("uid").and_then(|value| value.as_str()) {
+                let (method, endpoint) = if dst_datasource_uids.contains(&datasource_uid.to_string()) {
+                    (reqwest::Method::PUT, format!("{}/api/datasources/uid/{}", self.dst.host, datasource_uid))
+                } else {
+                    (reqwest::Method::POST, format!("{}/api/datasources", self.dst.host))
+                };
+
+                match client.request(method, &endpoint).json(&json_data).send().await {
+                    Err(e) => log::error!("Error importing datasource '{}' to '{}': {:?}", datasource_uid, endpoint, e),
+                    Ok(res) => {
+                        log::info!("Importing datasource '{}' to '{}' with status {}", datasource_uid, endpoint, res.status());
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn create_dir(dir_path: &str) -> Result<(), Box<dyn Error>> {
+    if !std::fs::exists(dir_path).unwrap_or(false) {
+        fs::create_dir(dir_path).map_err(|e| {
+            log::error!("Failed to create directory '{}': {}", dir_path, e);
+            e
+        })?;
+    }
+
+    Ok(())
+}
+
+fn list_dir(dir_path: &str) -> Vec<std::path::PathBuf> {
+    match fs::read_dir(dir_path) {
+        Ok(entries) => entries.filter_map(|entry| entry.ok().map(|e| e.path())).collect(),
+        Err(e) => {
+            log::error!("Failed to read directory '{}': {}", dir_path, e);
+            Vec::new()
+        },
+    }
+}
+
+fn get_config(config_file: &str) -> Result<Config, Box<dyn Error>> {
+    let file = std::fs::File::open(config_file).map_err(|e| {
+        log::error!("Failed to open config gile '{}': {}", config_file, e);
+        e
+    })?;
+
+    let config: Config = serde_yaml::from_reader(file)?;
+    Ok(config)
+}
+
+fn get_current_dir() -> Result<String, Box<dyn Error>> {
+    let current_dir = env::current_dir().map_err(|e|{
+        log::error!("Failed to get current dir: {}", e);
+        e
+    })?;
+
+    current_dir.to_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| {
+            let message = "Failed to convert current dir to string".to_string();
+            log::error!("{}", message);
+            message.into()
+        })
 }
 
 #[tokio::main]
@@ -412,9 +379,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config_file = std::env::var("CONFIG_FILE")
         .expect("environment variable `CONFIG_FILE` not found");
 
-    let grafana = get_config(&config_file)?;
-    grafana.export_dashboards().await?;
-    grafana.import_dashboards().await?;
+    let config = get_config(&config_file)?;
+    let (log_config, grafana) = (config.log_config, config.grafana);
+
+    log4rs::init_file(log_config.filepath, Default::default())
+        .expect("failed to init log4rs");
+
+    grafana.export().await?;
+    grafana.import().await?;
 
     Ok(())
 }


### PR DESCRIPTION
### Changes
- Split responsibilities into smaller functions for better readability and maintainability
- Use YAML config instead of environment variables
- Replace `println!` with proper logging
- Improve structure for exporting and importing folders, dashboards, and datasources in Grafana